### PR TITLE
Save organized point cloud

### DIFF
--- a/PointCloudsPython.cpp
+++ b/PointCloudsPython.cpp
@@ -119,6 +119,30 @@ extern "C" int PclSavePcd(char* fileName, float* points, int nPoints)
   return 0;
 }
 
+extern "C" int PclSaveOrganizedPcd(char* fileName, float* points, int nPoints, int height, int width)
+{
+  PointCloud<PointXYZ> cloud;
+  PclArrayToPointCloud(points, nPoints, cloud);
+
+  PointCloud<PointXYZ> cloud_organized;
+  cloud_organized.height = height;
+  cloud_organized.width = width;
+  cloud_organized.points.resize(height*width);
+
+  for (int i = 0; i < height; i++)
+  {
+    for (int j = 0; j < width; j++)
+    {
+      cloud_organized.at(j,i) = cloud.points[i*width + j];
+    }
+  }
+
+  if (savePCDFileASCII(fileName, cloud_organized) < 0)
+    return -1;
+
+  return 0;
+}
+
 extern "C" int PclVoxelize(float* pointsIn, int nPointsIn, float voxelSize, float** pointsOut, int* nPointsOut)
 {
   PointCloud<PointXYZ>::Ptr cloudIn(new PointCloud<PointXYZ>);

--- a/point_cloud.py
+++ b/point_cloud.py
@@ -34,6 +34,10 @@ PclSavePcd = PointCloudsPython.PclSavePcd
 PclSavePcd.restype = c_int
 PclSavePcd.argtypes = [POINTER(c_char), ndpointer(c_float, flags="C_CONTIGUOUS"), c_int]
 
+PclSaveOrganizedPcd = PointCloudsPython.PclSaveOrganizedPcd
+PclSaveOrganizedPcd.restype = c_int
+PclSaveOrganizedPcd.argtypes = [POINTER(c_char), ndpointer(c_float, flags="C_CONTIGUOUS"), c_int, c_int, c_int]
+
 PclVoxelize = PointCloudsPython.PclVoxelize
 PclVoxelize.restype = c_int
 PclVoxelize.argtypes = [ndpointer(c_float, flags="C_CONTIGUOUS"), c_int, c_float, POINTER(POINTER(c_float)), POINTER(c_int)]
@@ -227,6 +231,15 @@ def SavePcd(fileName, cloud):
 
   cloud = ascontiguousarray(cloud, dtype='float32')
   errorCode = PclSavePcd(fileName, cloud, cloud.shape[0])
+
+  if errorCode < 0:
+    raise Exception("Failed to save {}.".format(fileName))
+
+def SaveOrganizedPcd(fileName, cloud, height, width):
+  '''Reorganizes cloud and saves it to (ASCII) PCD file.'''
+
+  cloud = ascontiguousarray(cloud, dtype='float32')
+  errorCode = PclSaveOrganizedPcd(fileName, cloud, cloud.shape[0], height, width)
 
   if errorCode < 0:
     raise Exception("Failed to save {}.".format(fileName))


### PR DESCRIPTION
Added function to organize an unorganized point cloud so that it can be used with other functions that expect an organized cloud (e.g., to convert it to a depth image).